### PR TITLE
add oms central to required version matrix

### DIFF
--- a/content/docs/introduction/requirements.md
+++ b/content/docs/introduction/requirements.md
@@ -144,13 +144,13 @@ An installation of mSupply is currently required when running Open mSupply. This
 
 From v2.0.00, the Open mSupply central server is also required for successful synchronisation. See the [Open mSupply central server](/docs/getting_started/central/) and [Open mSupply central server site configuration in mSupply](https://docs.msupply.org.nz/synchronisation:sync_sites#open_msupply_central_server_settings) for more details.
 
-You will get the following error message the Open mSupply central server is not configured
+You will get the following error message if the Open mSupply central server is not configured:
 
 ![v6 not configured!](/docs/introduction/images/v6_not_configured.png)
 
 The versions of both central servers and your Open mSupply remote site are important, as not all versions of each are compatible with each other.
 
-The table below shows which versions of mSupply and Open mSupply Central you will require when running as Open mSupply remote site:
+The table below shows which versions of mSupply and Open mSupply Central you will require when running as an Open mSupply remote site:
 
 | Open mSupply Remote | mSupply Central | Open mSupply Central |
 | :------------------ | :-------------- | -------------------- |

--- a/content/docs/introduction/requirements.md
+++ b/content/docs/introduction/requirements.md
@@ -37,13 +37,13 @@ The server requires a little more memory and processing capability, depending on
 
 Hardware requirements vary widely depending on what you want to use Open mSupply for. Here's a rough guide:
 
-| Machine | Technical Minimum | Recommended |
-| :---------- | :---------- | :---------- |
-| Windows Client machine for use with server | 64 bit processor<br/>Windows 10<br/>4 Gb RAM, 300Mb of disk space	| 64 bit processor<br/>Windows 10<br/>8 Gb RAM, 500Mb of disk space |
-| Mac Client machine for use with server | 64 bit processor<br/>macOS Mojave (10.14) – macOS Big Sur (11)(Latest release of major version is required, such as 10.14.6)<br/>4 Gb RAM, 300Mb of disk space	| 64 bit processor<br/>Mac OS 10.14.6 or later<br/>8 Gb RAM, 500Mb of disk space |
-| Windows server | 64 bit processor<br/>Windows 10 Pro or Win server 2019<br/>8 Gb RAM<br/>50 GB HDD/SDD volume with daily backups to an external volume| 64 bit processor<br/>Windows Server 2019+<br/>8 Gb RAM<br/>4 x HDD/SDD volumes, 3 configured as RAID1 or RAID5 with hot spare<br/>Daily backups to the fourth volume plus daily off-site backups<br/>Attached to a Smart UPS (see below) |
-| Linux client or server | 64 bit processor<br/>Ubuntu 20+ or similar<br/>4 Gb RAM<br/>256 Gb storage | 64 bit processor<br/>Ubuntu 20+ or similar<br/>8 Gb RAM<br/>256 Gb storage |
-| Android client or server | 64 bit processor<br/>Android 10 or later<br/>4 Gb RAM<br/>64 Gb storage | 64 bit processor<br/>Android 10 or later<br/>4 Gb RAM<br/>64 Gb storage |
+| Machine                                    | Technical Minimum                                                                                                                                              | Recommended                                                                                                                                                                                                                              |
+| :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Windows Client machine for use with server | 64 bit processor<br/>Windows 10<br/>4 Gb RAM, 300Mb of disk space                                                                                              | 64 bit processor<br/>Windows 10<br/>8 Gb RAM, 500Mb of disk space                                                                                                                                                                        |
+| Mac Client machine for use with server     | 64 bit processor<br/>macOS Mojave (10.14) – macOS Big Sur (11)(Latest release of major version is required, such as 10.14.6)<br/>4 Gb RAM, 300Mb of disk space | 64 bit processor<br/>Mac OS 10.14.6 or later<br/>8 Gb RAM, 500Mb of disk space                                                                                                                                                           |
+| Windows server                             | 64 bit processor<br/>Windows 10 Pro or Win server 2019<br/>8 Gb RAM<br/>50 GB HDD/SDD volume with daily backups to an external volume                          | 64 bit processor<br/>Windows Server 2019+<br/>8 Gb RAM<br/>4 x HDD/SDD volumes, 3 configured as RAID1 or RAID5 with hot spare<br/>Daily backups to the fourth volume plus daily off-site backups<br/>Attached to a Smart UPS (see below) |
+| Linux client or server                     | 64 bit processor<br/>Ubuntu 20+ or similar<br/>4 Gb RAM<br/>256 Gb storage                                                                                     | 64 bit processor<br/>Ubuntu 20+ or similar<br/>8 Gb RAM<br/>256 Gb storage                                                                                                                                                               |
+| Android client or server                   | 64 bit processor<br/>Android 10 or later<br/>4 Gb RAM<br/>64 Gb storage                                                                                        | 64 bit processor<br/>Android 10 or later<br/>4 Gb RAM<br/>64 Gb storage                                                                                                                                                                  |
 
 <div class="note">
 Recording stock transactions is a core Open mSupply activity. Most stock transaction data is numeric. A numeric keypad is often helpful for machines that have a lot of data entry done on them.
@@ -59,20 +59,20 @@ Recommended Specifications:
 In short, Open mSupply mobile runs on Android tablets (not on phones as there is too much data to use well on small phone screens).
 The application requires at least Android 5.0 (Lollipop)
 
-|           | Minimum | Recommended |
-| :-------- | :------ | :---------- |
-| Display size | 9.8 inches | 10.1 inches |
-| Resolution   | 768 x 1024 pixels | 800 x 1200 pixels |
-| Android version | 5.0 | 8.1 |
-| Processor | | Quad-core 1.3GHz |
-| Memory | | 1.5 Gb RAM |
+|                 | Minimum           | Recommended       |
+| :-------------- | :---------------- | :---------------- |
+| Display size    | 9.8 inches        | 10.1 inches       |
+| Resolution      | 768 x 1024 pixels | 800 x 1200 pixels |
+| Android version | 5.0               | 8.1               |
+| Processor       |                   | Quad-core 1.3GHz  |
+| Memory          |                   | 1.5 Gb RAM        |
 
 In order to provide support, the device must also be compatible with MDM (Mobile Device Management) software and support google services. Please contact [mSupply Foundation](https://msupply.foundation/#contact) for details.
-
 
 Please contact us for testing and/or advice before making a large hardware purchase.
 
 ### Smart UPS
+
 A 'smart' UPS ([Uninterruptible Power Supply](https://en.wikipedia.org/wiki/Uninterruptible_power_supply)) detects when the battery power is about to run out and sends a notification to software on the server which triggers a graceful shut down of the computer. To enable this, there needs to be a cable connection (normally USB) between the UPS and the computer combined with software running on the computer.
 
 In our experience, the primary cause of computer hardware failure is data corruption due to ungraceful shutdowns. This happens when power to the computer is cut instantly, without any notification to the computer to shut down gracefully. If the machine is 'protected' by a normal UPS, then this can still happen when the battery power runs out. Even if the machine is notionally protected by a 'smart' UPS, there are a number of circumstances where this UPS protection fails:
@@ -108,17 +108,20 @@ Useful productivity accessories for laptop computers include
 - External screen
 
 ## Bandwidth and Latency requirements
+
 Firstly, this is a good time to mention our synchronisation system, which has saved many countries from a failed installation!
 
 #### Offline (Sync) mode
-* 128kbps bandwidth
-* high latency (e.g. satellite) is OK, and users will not notice it in day-to-day operations, as sync is running in the background, and requests for data is fulfilled from the local database, not over the internet.
-* intermittent (say only once a week) is OK
+
+- 128kbps bandwidth
+- high latency (e.g. satellite) is OK, and users will not notice it in day-to-day operations, as sync is running in the background, and requests for data is fulfilled from the local database, not over the internet.
+- intermittent (say only once a week) is OK
 
 #### Cloud hosted (Online) mode
-* The initial download of Javascript code is around 1 Mb, so a 512kbps connection or faster is best (loads in 10 seconds or so)
-* You need an internet connection on to use Open mSupply in this mode.
-* high latency (e.g. a satellite or overloaded connection) will result in slower performance
+
+- The initial download of Javascript code is around 1 Mb, so a 512kbps connection or faster is best (loads in 10 seconds or so)
+- You need an internet connection on to use Open mSupply in this mode.
+- high latency (e.g. a satellite or overloaded connection) will result in slower performance
 
 ## Backup system
 
@@ -126,8 +129,8 @@ Once you start using Open mSupply, it's important that you have a method of back
 
 - If not using our internet backup service, you need to be able to store backed up data off-site to prevent the risk of loss by fire, theft, etc.
 
-
 ## Antivirus
+
 Windows based operating systems are particularly prone to malware if precautions are not taken. We recommend the following precautions:
 
 - Install a reputable anti-virus program, including web protection if the computer has access to the internet
@@ -135,27 +138,27 @@ Windows based operating systems are particularly prone to malware if precautions
 
 Ensure that access to passwords which allow exceptions to the above two measures are kept secure.
 
-## mSupply
-An installation of mSupply is currently required when running Open mSupply (this is used to manage a number of centralised aspects of the system). 
-The version of both mSupply and Open mSupply is important, as not all versions of each are compatible with each other. 
+## Central Servers
 
-The table below shows which version of mSupply you will require when running Open mSupply:
+An installation of mSupply is currently required when running Open mSupply. This is used to manage a number of centralised aspects of the system.
 
-| Open mSupply         | mSupply               |
-| :--------------- | :-------------------- |
-| 1.1.00 - 1.1.16  | 7.04.01+              |
-| 1.2.00+          | 7.05.05+              |
-| 1.4.00+          | 7.09.00+              |
-| 2.0.00+          | 7.14.04+              |
-
-If you attempt to connect to an incompatible server you'll get an error message like this:
-
-![server version mismatch!](/docs/introduction/images/version_mismatch.png)
-
-## Open mSupply central server
-
-From v2.0.00, the Open mSupply central server is required for successful synchronisation. See the [Open mSupply central server](/docs/getting_started/central/) and [Open mSupply central server site configuration in mSupply](https://docs.msupply.org.nz/synchronisation:sync_sites#open_msupply_central_server_settings) for more details. 
+From v2.0.00, the Open mSupply central server is also required for successful synchronisation. See the [Open mSupply central server](/docs/getting_started/central/) and [Open mSupply central server site configuration in mSupply](https://docs.msupply.org.nz/synchronisation:sync_sites#open_msupply_central_server_settings) for more details.
 
 You will get the following error message the Open mSupply central server is not configured
 
 ![v6 not configured!](/docs/introduction/images/v6_not_configured.png)
+
+The versions of both central servers and your Open mSupply remote site are important, as not all versions of each are compatible with each other.
+
+The table below shows which versions of mSupply and Open mSupply Central you will require when running as Open mSupply remote site:
+
+| Open mSupply Remote | mSupply Central | Open mSupply Central |
+| :------------------ | :-------------- | -------------------- |
+| 1.1.00 - 1.1.16     | 7.04.01+        | N/A                  |
+| 1.2.00+             | 7.05.05+        | N/A                  |
+| 1.4.00+             | 7.09.00+        | N/A                  |
+| 2.0.00+             | 7.14.04+        | 2.0.00+              |
+
+If you attempt to connect to an incompatible server you'll get an error message like this:
+
+![server version mismatch!](/docs/introduction/images/version_mismatch.png)


### PR DESCRIPTION
Adds required versions of open msupply central for different open msupply remote versions.

It's after 5 and I'm not sure about the wording, let me know if it doesn't make as much sense as it should 😅 