### PR TITLE
Open mSupply version requirement

### DIFF
--- a/content/docs/introduction/requirements.md
+++ b/content/docs/introduction/requirements.md
@@ -159,6 +159,7 @@ The table below shows which versions of mSupply and Open mSupply Central you wil
 | 1.4.00+             | 7.09.00+        | N/A                  |
 | 2.0.00+             | 7.14.04+        | 2.0.00+              |
 | 2.1.00+             | 7.14.04+        | 2.1.00+              |
+| 2.2.00+             | 7.14.04+        | 2.2.00+              |
 
 If you attempt to connect to an incompatible server you'll get an error message like this:
 


### PR DESCRIPTION
Adds the v2.2.00 central server version requirement.