### PR TITLE
4679 add standard report translations docs

### DIFF
--- a/content/docs/getting_started/report.md
+++ b/content/docs/getting_started/report.md
@@ -82,4 +82,4 @@ The report will be downloaded as an excel file.
 
 Standard reports will be translated to the user's language if available when generating the report.
 
-If unavailable, english translations will be used as a default.
+If a translation in the user's language is unavailable, an english translation will be used as a default.

--- a/content/docs/getting_started/report.md
+++ b/content/docs/getting_started/report.md
@@ -82,4 +82,4 @@ The report will be downloaded as an excel file.
 
 Standard reports will be translated to the user's language if available when generating the report.
 
-If a translation in the user's language is unavailable, an english translation will be used as a default.
+English will be used by default in places where translations in the user's language is unavailable.

--- a/content/docs/getting_started/report.md
+++ b/content/docs/getting_started/report.md
@@ -77,3 +77,9 @@ To export a report to excel, click on the `Export` button on the top right corne
 ![export button](/docs/getting_started/images/export_button.png)
 
 The report will be downloaded as an excel file.
+
+### Standard report translations
+
+Standard reports will be translated to the user's language if available when generating the report.
+
+If unavailable, english translations will be used as a default.


### PR DESCRIPTION
Add front end user changing documentation for standard report translations.

Related to omSupply PR:
https://github.com/msupply-foundation/open-msupply/pull/4752