### PR TITLE
Oms indicators docs

### DIFF
--- a/content/docs/programs/program_indicators.md
+++ b/content/docs/programs/program_indicators.md
@@ -14,15 +14,18 @@ toc = true
 top = false
 +++
 
-Program Indicators are essentially sets of configurable survey questions that can be answered as part of a program requisition. They are recorded against the period that the program requisition is created for and used in reporting.
+The term 'Program Indicators' refers to a set of configurable survey questions which can be answered as part of a program requisition. They are recorded against the period of the program requisition and used for reporting purposes.
 
 ## Enabling Program Indicators
 
-Program Indicators are configured on the mSupply Primary Server, following the documenation [here](https://docs.msupply.org.nz/items:programs#adding_indicators_to_a_program).
+Program Indicators are configured on the mSupply central server, following the documentation [here](https://docs.msupply.org.nz/items:programs#adding_indicators_to_a_program).
 
 ## Manual Customer Requisitions
 
-Manual Customer Requisitions can be made to other stores as a fallback if device that store is meant to be active on is no longer operational.
+Manual Customer Requisitions can be made to other stores as a fallback if the Open mSupply store is not able to create a requisition itself (e.g. if
+the tablet or laptop used by that store is no longer operational).
+
+The process of entering program indicators is as follows:
 
 1. Create a manual requisition to another store as described [here](/docs/distribution/requisitions/#manual-requisition)
 2. Click on the Indicators tab
@@ -37,4 +40,4 @@ HIV is only available on Programs where "HIV" has been enabled.
 
 ![Indicators edit](/docs/programs/images/indicators_edit.png)
 
-From here you can enter in the data entry configured for each indicator configured for this program.
+From here you can enter in the data, as configured for each indicator of this program.

--- a/content/docs/programs/requisitions.md
+++ b/content/docs/programs/requisitions.md
@@ -105,8 +105,12 @@ items manually to the Requisition.
 
 #### Extra Requisition Fields
 
-In manual requisitions it is possible to collect many additional columns of data for reporting and forcasting purposes. To enable these columns you need to configure store permissions to enable these extra columns as documenting in mSupply Desktop documentation [here](https://docs.msupply.org.nz/other_stuff:virtual_stores#preferences_tab). For quick reference this is the preference your logged in store requires:
+In manual requisitions it is possible to collect many additional columns of data for reporting and forecasting purposes. To enable these columns you need to configure store preferences to enable these extra columns as described in the [mSupply Desktop documentation](https://docs.msupply.org.nz/other_stuff:virtual_stores#preferences_tab).
+
+For quick reference this is the preference your logged-in store requires:
 ![Show extra fields on requisitions preference](/docs/programs/images/show_extra_fields_on_requisitions.png)
+
+This is how the extra columns look within a requisition:
 
 ![Program Requisition Detail
 View](/docs/programs/images/program_requisition_detail_view.gif)


### PR DESCRIPTION
I've reviewed the changes in https://github.com/msupply-foundation/msupply_docs/pull/124.. a little too late!

here are my requested changes / corrections.

I would also question the use of 'mSupply' as in `...for customers who do not use mSupply...` etc. It applies to `Open mSupply` and `mSupply` right? Though these are the open mSupply docs, so I thought that referring to mSupply here might be confusing for users?